### PR TITLE
Make remote auth token optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Analyze MCP servers for naming, routing, and semantic tool conflicts.
 npx mcp-watchtower scan --server "uvx my-server"
 ```
 
+By default, a scan runs both the deterministic static checks and the deeper semantic analysis pass.
+
 ## CLI
 
 ```bash
@@ -50,11 +52,14 @@ npx mcp-watchtower scan --server "uvx my-server" --json
 # Treat static name collisions as critical
 npx mcp-watchtower scan --server "uvx my-server" --platform
 
-# Semantic overlap detection against the corpus index
+# Syntactic-only scan
+npx mcp-watchtower scan --server "uvx my-server" --syntactic
+
+# Semantic-only scan
 npx mcp-watchtower scan --server "uvx my-server" --semantic
 
 # Tune semantic sensitivity
-npx mcp-watchtower scan --server "uvx my-server" --semantic --threshold 0.8
+npx mcp-watchtower scan --server "uvx my-server" --threshold 0.8
 ```
 
 `--auth-token` is optional for `--remote` and is only needed when the endpoint requires bearer authentication.
@@ -73,6 +78,9 @@ npx mcp-watchtower scan --server "uvx my-server" --semantic --threshold 0.8
 
 - `ALREADY_IN_CORPUS` — the tool appears to already exist in the corpus
 - `SEMANTIC_OVERLAP` — the tool looks close to an existing tool and may need clearer disambiguation
+- `SEMANTIC_PARAMETER_CONFLICT` — two parameters in the same server look semantically equivalent despite inconsistent names
+
+Plain `scan` runs both layers. Use `--syntactic` for only the deterministic checks or `--semantic` for only the deeper semantic pass.
 
 ## Index behavior
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,10 @@ npx mcp-watchtower scan --server "uvx my-server"
 # Local MCP server over stdio
 npx mcp-watchtower scan --server "uvx my-server"
 
-# Remote MCP endpoint
+# Remote MCP endpoint without auth
+npx mcp-watchtower scan --remote "https://api.example.com/mcp"
+
+# Remote MCP endpoint with bearer auth
 npx mcp-watchtower scan --remote "https://api.example.com/mcp" --auth-token "$MCP_TOKEN"
 
 # Manifest / CI input
@@ -53,6 +56,8 @@ npx mcp-watchtower scan --server "uvx my-server" --semantic
 # Tune semantic sensitivity
 npx mcp-watchtower scan --server "uvx my-server" --semantic --threshold 0.8
 ```
+
+`--auth-token` is optional for `--remote` and is only needed when the endpoint requires bearer authentication.
 
 ## What it checks
 

--- a/cli/analysis.ts
+++ b/cli/analysis.ts
@@ -1,0 +1,16 @@
+export interface AnalysisModeOptions {
+  semantic?: boolean
+  syntactic?: boolean
+}
+
+export interface AnalysisMode {
+  runStatic: boolean
+  runSemantic: boolean
+}
+
+export function resolveAnalysisMode(options: AnalysisModeOptions): AnalysisMode {
+  return {
+    runStatic: !!options.syntactic || !options.semantic,
+    runSemantic: !!options.semantic || !options.syntactic,
+  }
+}

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -37,7 +37,7 @@ program
   .description('Scan an MCP server for tool conflicts and compatibility issues')
   .option('-s, --server <command>', 'command to start the MCP server process')
   .option('-r, --remote <url>',      'remote MCP endpoint URL (e.g. https://api.example.com/mcp)')
-  .option('-t, --auth-token <token>', 'bearer token for --remote MCP endpoint')
+  .option('-t, --auth-token <token>', 'optional bearer token for a protected --remote MCP endpoint')
   .option('-m, --manifest <path>',  'path to a JSON file containing tools (CI fallback)')
   .option('-n, --name <name>',      'server name for the report')
   .option('-j, --json',             'output results as JSON')
@@ -99,8 +99,7 @@ async function resolveTools(options: {
 
   if (mode === 'remote') {
     const endpoint = options.remote!
-    const token = options.authToken!
-    const tools = await fetchToolsFromRemoteServer(endpoint, token)
+    const tools = await fetchToolsFromRemoteServer(endpoint, options.authToken)
     const serverName = options.name ?? deriveServerNameFromUrl(endpoint)
     return { tools, serverName }
   }
@@ -163,7 +162,7 @@ async function fetchToolsFromLocalServer(command: string): Promise<ToolSchema[]>
   }
 }
 
-async function fetchToolsFromRemoteServer(endpoint: string, token: string): Promise<ToolSchema[]> {
+async function fetchToolsFromRemoteServer(endpoint: string, token?: string): Promise<ToolSchema[]> {
   let url: URL
   try {
     url = new URL(endpoint)
@@ -173,13 +172,15 @@ async function fetchToolsFromRemoteServer(endpoint: string, token: string): Prom
 
   process.stderr.write(`Connecting to remote server: ${url.toString()}\n`)
 
-  const transport = new StreamableHTTPClientTransport(url, {
-    requestInit: {
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-    },
-  })
+  const transport = new StreamableHTTPClientTransport(url, token
+    ? {
+        requestInit: {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        },
+      }
+    : undefined)
 
   const client = new Client(
     { name: 'mcp-watchtower', version: '0.1.0' },
@@ -200,7 +201,7 @@ async function fetchToolsFromRemoteServer(endpoint: string, token: string): Prom
     await closeClient(client)
     throw new Error(
       `Failed to connect to remote MCP endpoint "${endpoint}".\n` +
-      `Make sure the endpoint is reachable and the bearer token is valid.\n` +
+      `Make sure the endpoint is reachable and any supplied bearer token is valid.\n` +
       `Details: ${(err as Error).message}`
     )
   }

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -14,6 +14,7 @@ import {
   resolveInputMode,
   type ScanInputOptions,
 } from './input.js'
+import { resolveAnalysisMode } from './analysis.js'
 
 const program = new Command()
 
@@ -43,8 +44,9 @@ program
   .option('-j, --json',             'output results as JSON')
   .option('-p, --platform',         'platform mode: elevates name collision severity to critical')
   .option('--max-tools <number>',   'maximum tools before warning (default: 20)', '20')
-  .option('--semantic',             'run semantic overlap detection against the corpus index')
-  .option('--threshold <number>',   'similarity threshold 0-1 (default: 0.75, used with --semantic)', parseThreshold)
+  .option('--syntactic',            'run only deterministic syntactic/static checks')
+  .option('--semantic',             'run only semantic overlap detection plus deep semantic parameter analysis')
+  .option('--threshold <number>',   'similarity threshold 0-1 (default: 0.75, used when semantic analysis runs)', parseThreshold)
   .action(async (options: ScanOptions) => {
     try {
       try {
@@ -54,12 +56,20 @@ program
       }
       printBanner(options)
       const { tools, serverName } = await resolveTools(options)
+      const { runStatic, runSemantic } = resolveAnalysisMode(options)
       const staticAnalyzer = new StaticAnalyzer({
         platform: !!options.platform,
         maxTools: parseInt(options.maxTools, 10),
       })
-      const staticReport = staticAnalyzer.analyze(serverName, tools)
-      const semanticFindings = options.semantic
+      const staticReport = runStatic
+        ? staticAnalyzer.analyze(serverName, tools)
+        : {
+            server: serverName,
+            toolCount: tools.length,
+            findings: [],
+            passedAt: new Date().toISOString(),
+          }
+      const semanticFindings = runSemantic
         ? (await new SemanticAnalyzer({ threshold: options.threshold }).analyze(serverName, tools)).findings
         : []
       const hasCritical = staticReport.findings.some(f => f.severity === 'critical')
@@ -120,6 +130,7 @@ interface ScanOptions extends ScanInputOptions {
   name?: string
   json?: boolean
   platform?: boolean
+  syntactic?: boolean
   semantic?: boolean
   threshold?: number
   maxTools: string
@@ -295,7 +306,7 @@ function printHuman(
 
     if (isSemanticFinding(finding)) {
       process.stdout.write(
-        `  ${finding.matchedTool} in ${finding.matchedDisplayName} (similarity: ${finding.similarity.toFixed(2)})\n`,
+        `  ${finding.matchedParameter ? `${finding.matchedParameter} in ` : ''}${finding.matchedTool} in ${finding.matchedDisplayName} (similarity: ${finding.similarity.toFixed(2)})\n`,
       )
       process.stdout.write(`  ${finding.message}\n`)
     } else {

--- a/cli/input.ts
+++ b/cli/input.ts
@@ -19,9 +19,6 @@ export function resolveInputMode(options: ScanInputOptions, stdinIsTTY: boolean)
   }
 
   if (options.remote) {
-    if (!options.authToken) {
-      throw new Error('Missing auth token. Use --auth-token when connecting with --remote.')
-    }
     return 'remote'
   }
 
@@ -32,7 +29,7 @@ export function resolveInputMode(options: ScanInputOptions, stdinIsTTY: boolean)
   throw new Error(
     'No input provided. Examples:\n\n' +
     '  npx mcp-watchtower scan --server "python my_server.py"\n' +
-    '  npx mcp-watchtower scan --remote "https://api.example.com/mcp" --auth-token "$TOKEN"\n' +
+    '  npx mcp-watchtower scan --remote "https://api.example.com/mcp"\n' +
     '  npx mcp-watchtower scan --manifest ./tools.json\n'
   )
 }

--- a/docs/api/overview.mdx
+++ b/docs/api/overview.mdx
@@ -94,7 +94,7 @@ const staticReport = analyzer.analyze('my-server', tools)
 const semanticReport = await new SemanticAnalyzer({ threshold: 0.8 }).analyze('my-server', tools)
 
 const criticals = staticReport.findings.filter(f => f.severity === 'critical')
-const semanticWarnings = semanticReport.findings.filter(f => f.code === 'SEMANTIC_OVERLAP')
+const semanticWarnings = semanticReport.findings.filter(f => f.severity === 'warning')
 
 if (criticals.length > 0) {
   console.error(`Analysis failed with ${criticals.length} critical finding(s):`)
@@ -114,7 +114,7 @@ console.log(semanticReport.findings)
 </Tip>
 
 <Note>
-  `SemanticAnalyzer` is asynchronous because it embeds tool descriptions at runtime and queries the shipped semantic index. The CLI uses the same class behind `mcp-watchtower scan --semantic`.
+  `SemanticAnalyzer` is asynchronous because it embeds tool and parameter context at runtime and queries the shipped semantic index. The CLI runs the same class in the default full scan and in `--semantic` mode.
 </Note>
 
 ## Next steps

--- a/docs/api/semantic-analyzer.mdx
+++ b/docs/api/semantic-analyzer.mdx
@@ -1,14 +1,14 @@
 ---
 title: "SemanticAnalyzer class reference"
-description: "Full reference for the SemanticAnalyzer class: constructor options, matching behavior, and the SemanticReport shape."
+description: "Full reference for the SemanticAnalyzer class: constructor options, corpus overlap behavior, semantic parameter matching, and the SemanticReport shape."
 ---
 
-`SemanticAnalyzer` compares your tool descriptions against MCP tools in the semantic corpus. Today that corpus is built from Smithery data and shipped as an HNSW index plus metadata file. The analyzer runs locally against the index; it does not call Smithery during `analyze()`.
+`SemanticAnalyzer` compares your tool descriptions against MCP tools in the semantic corpus and also performs a deeper semantic parameter pass within the server you are scanning. Today the corpus is built from Smithery data and shipped as an HNSW index plus metadata file. The analyzer runs locally against that index; it does not call Smithery during `analyze()`.
 
 ## Constructor
 
 ```typescript
-new SemanticAnalyzer(config?: { threshold?: number; topK?: number })
+new SemanticAnalyzer(config?: { threshold?: number; topK?: number; parameterThreshold?: number })
 ```
 
 Pass an optional configuration object to tune how strictly the analyzer matches tools.
@@ -28,6 +28,10 @@ const strictAnalyzer = new SemanticAnalyzer({ threshold: 0.85, topK: 5 })
 
 <ParamField path="config.topK" type="number" default="10">
   Number of nearest neighbors to retrieve from the semantic index for each tool before threshold filtering is applied. Higher values increase recall at the cost of more comparison work.
+</ParamField>
+
+<ParamField path="config.parameterThreshold" type="number" default="0.88">
+  Minimum similarity score required before the within-server semantic parameter matcher emits `SEMANTIC_PARAMETER_CONFLICT`. When omitted, Watchtower uses the stricter of `threshold` and `0.88` to keep the deeper pass conservative by default.
 </ParamField>
 
 ## analyze()
@@ -76,8 +80,9 @@ For each tool, `SemanticAnalyzer`:
 2. builds a retrieval query from `tool.name + tool.description`
 3. searches the local HNSW index for the nearest neighbors
 4. recomputes similarity from descriptions when the tool names are identical
-5. filters matches below `threshold` and matches from the same server
-6. emits either `ALREADY_IN_CORPUS` or `SEMANTIC_OVERLAP`
+5. performs a within-server semantic parameter pass using parameter and tool context
+6. filters corpus matches below `threshold`, filters parameter matches below `parameterThreshold`, and drops corpus matches from the same server
+7. emits `ALREADY_IN_CORPUS`, `SEMANTIC_OVERLAP`, and when applicable `SEMANTIC_PARAMETER_CONFLICT`
 
 <Info>
   The analyzer loads index files from `~/.mcp-watchtower/index` when a newer downloaded index is present. Otherwise it falls back to the bundled `semantic.hnsw` and `semantic-meta.json` files shipped with the package.
@@ -119,8 +124,8 @@ import { SemanticAnalyzer } from 'mcp-watchtower'
 const analyzer = new SemanticAnalyzer({ threshold: 0.85, topK: 5 })
 const report = await analyzer.analyze('my-server', tools)
 
-const overlaps = report.findings.filter(f => f.code === 'SEMANTIC_OVERLAP')
-console.log(`Found ${overlaps.length} strong overlap(s)`)
+const warnings = report.findings.filter(f => f.severity === 'warning')
+console.log(`Found ${warnings.length} semantic warning(s)`)
 ```
 
 </CodeGroup>

--- a/docs/api/types.mdx
+++ b/docs/api/types.mdx
@@ -129,7 +129,7 @@ const tool: ToolSchema = {
   <Accordion title="PARAMETER_CONFLICT">
     **Default severity:** `warning`
 
-    Two tools use different parameter names for the same semantic concept — for example, `ticker` in one tool and `symbol` in another. The analyzer checks against a built-in list of synonym groups covering common patterns like identifiers, pagination, and date fields.
+    Two tools use different parameter names for the same semantic concept — for example, `ticker` in one tool and `symbol` in another. The analyzer uses deterministic normalization plus a built-in synonym seed set covering common patterns like identifiers, pagination, and date fields.
 
     Both the `tool` and `relatedTool` fields are set.
 
@@ -221,10 +221,10 @@ const tool: ToolSchema = {
 `SemanticFinding` represents a single result produced by `SemanticAnalyzer`. Semantic findings are separate from static `Finding` objects because they carry corpus match metadata.
 
 <ResponseField name="severity" type="'warning' | 'info'" required>
-  Semantic findings are never `critical`. `SEMANTIC_OVERLAP` is a `warning`, while `ALREADY_IN_CORPUS` is typically `info`.
+  Semantic findings are never `critical`. `SEMANTIC_OVERLAP` and `SEMANTIC_PARAMETER_CONFLICT` are `warning` findings, while `ALREADY_IN_CORPUS` is typically `info`.
 </ResponseField>
 
-<ResponseField name="code" type="'SEMANTIC_OVERLAP' | 'ALREADY_IN_CORPUS'" required>
+<ResponseField name="code" type="'SEMANTIC_OVERLAP' | 'ALREADY_IN_CORPUS' | 'SEMANTIC_PARAMETER_CONFLICT'" required>
   Machine-readable identifier for the semantic match type.
 </ResponseField>
 
@@ -242,6 +242,10 @@ const tool: ToolSchema = {
 
 <ResponseField name="matchedDisplayName" type="string" required>
   Human-readable display name for the matched corpus server.
+</ResponseField>
+
+<ResponseField name="matchedParameter" type="string">
+  Parameter name involved in a `SEMANTIC_PARAMETER_CONFLICT` finding. Omitted for corpus-overlap findings.
 </ResponseField>
 
 <ResponseField name="similarity" type="number" required>
@@ -289,6 +293,28 @@ const tool: ToolSchema = {
       matchedDisplayName: 'Acme Search Server',
       similarity: 0.82,
       message: "'search_docs' is semantically similar to 'query_documents' in Acme Search Server (similarity: 0.82) — consider adding disambiguation to your description",
+    }
+    ```
+  </Accordion>
+
+  <Accordion title="SEMANTIC_PARAMETER_CONFLICT">
+    **Default severity:** `warning`
+
+    Two parameters in the same scanned server look semantically equivalent even though they use different names. This finding comes from the deeper semantic parameter pass, which compares parameter names and descriptions in the context of their surrounding tools.
+
+    The `tool`, `matchedTool`, and `matchedParameter` fields are set. `matchedServer` and `matchedDisplayName` are set to the scanned server name because the comparison is within one server, not against the external corpus.
+
+    ```typescript
+    {
+      severity: 'warning',
+      code: 'SEMANTIC_PARAMETER_CONFLICT',
+      tool: 'list_portfolios',
+      matchedTool: 'summarize_allocations',
+      matchedServer: 'portfolio-server',
+      matchedDisplayName: 'portfolio-server',
+      matchedParameter: 'holdings',
+      similarity: 0.93,
+      message: "Parameter 'portfolio_ids' in 'list_portfolios' is semantically similar to 'holdings' in 'summarize_allocations' (similarity: 0.93) — consider using a shared name or clearer descriptions",
     }
     ```
   </Accordion>

--- a/docs/checks/overview.mdx
+++ b/docs/checks/overview.mdx
@@ -21,7 +21,7 @@ MCP Watchtower runs five deterministic checks against your server's tool definit
   <Card title="Parameter conflict detection" icon="arrows-left-right">
     **Severity: warning**
 
-    Identifies tools that use different parameter names for the same concept — for example, one tool using `ticker` while another uses `symbol`. Uses built-in synonym groups.
+    Identifies tools that use different parameter names for the same concept — for example, one tool using `ticker` while another uses `symbol`. Uses deterministic normalization and common built-in synonym handling.
   </Card>
   <Card title="Shadow pattern detection" icon="eye-off">
     **Severity: warning or critical**
@@ -102,6 +102,8 @@ The analyzer uses a majority-wins rule. Names that do not match one of those pat
 - **Why it matters:** chained tool calls become ambiguous when one tool expects `ticker` and another expects `symbol`
 - **How to fix it:** standardize on one name everywhere that concept appears
 
+The static check is intentionally deterministic and local-first. It catches common cases through normalization plus a compact synonym seed set, but niche domain aliases may require the deeper semantic pass available in the default full scan or in `--semantic` mode.
+
 Built-in synonym groups include:
 
 | Concept | Recognized names |
@@ -114,6 +116,8 @@ Built-in synonym groups include:
 | Resource location | `url`, `uri`, `endpoint`, `href` |
 | User reference | `user`, `username`, `user_id`, `userId` |
 | Time reference | `date`, `timestamp`, `time`, `datetime` |
+
+If you need broader coverage for organization-specific or niche terms, run the semantic workflow too. That deeper pass can emit `SEMANTIC_PARAMETER_CONFLICT` when two parameters look semantically equivalent even though the static checker could not prove it from deterministic rules alone.
 
 ### Shadow patterns
 

--- a/docs/cli/scan.mdx
+++ b/docs/cli/scan.mdx
@@ -6,6 +6,8 @@ description: "Compact reference for the mcp-watchtower CLI: input modes, all sca
 
 `scan` is the only command most developers need. Use it with a local server, a remote MCP endpoint, a manifest file, or stdin.
 
+By default, `scan` runs both the deterministic static checks and the deeper semantic analysis pass. Use `--syntactic` for only the deterministic checks or `--semantic` for only the semantic layer.
+
 ## Synopsis
 
 ```bash
@@ -17,7 +19,7 @@ npx mcp-watchtower scan [options]
 | Mode | Flag | Use it when |
 | --- | --- | --- |
 | Local server | `--server "<command>"` | You want Watchtower to start your MCP server over stdio |
-| Remote endpoint | `--remote "<url>" --auth-token "$TOKEN"` | Your MCP server is already exposed over HTTP |
+| Remote endpoint | `--remote "<url>"` | Your MCP server is already exposed over HTTP |
 | Manifest file | `--manifest ./tools.json` | You already export tool definitions during build or CI |
 | Stdin | no input flag | You want to pipe a tools JSON document directly into the scan |
 
@@ -35,14 +37,15 @@ Manifest and stdin accept:
 | --- | --- | --- |
 | `--server <command>` | `-s` | Start a local MCP server process over stdio |
 | `--remote <url>` | `-r` | Connect to a remote MCP endpoint |
-| `--auth-token <token>` | `-t` | Bearer token required with `--remote` |
+| `--auth-token <token>` | `-t` | Optional bearer token for protected `--remote` endpoints |
 | `--manifest <path>` | `-m` | Read tools from a local JSON file |
 | `--name <name>` | `-n` | Override the server label shown in the report |
 | `--json` | `-j` | Emit machine-readable JSON instead of human-readable output |
 | `--platform` | `-p` | Elevate duplicate tool names to critical in shared tool namespaces |
 | `--max-tools <number>` | — | Set a custom tool count threshold |
-| `--semantic` | — | Add semantic overlap detection against the current corpus |
-| `--threshold <number>` | — | Set the semantic similarity threshold (0-1, default: `0.75`) |
+| `--syntactic` | — | Run only deterministic syntactic/static checks |
+| `--semantic` | — | Run only semantic overlap detection and deep semantic parameter analysis |
+| `--threshold <number>` | — | Set the semantic similarity threshold (0-1, default: `0.75`) when semantic analysis runs |
 
 ## Examples
 
@@ -61,6 +64,10 @@ npx mcp-watchtower scan --server "uvx my-published-server"
 ```
 
 ```bash Remote endpoint
+npx mcp-watchtower scan --remote "https://api.example.com/mcp"
+```
+
+```bash Remote endpoint with auth
 npx mcp-watchtower scan \
   --remote "https://api.example.com/mcp" \
   --auth-token "$MCP_TOKEN"
@@ -89,12 +96,20 @@ npx mcp-watchtower scan --server "node dist/server.js" --platform
 npx mcp-watchtower scan --server "node dist/server.js" --max-tools 15
 ```
 
-```bash Semantic overlap detection
+```bash Default full scan
+npx mcp-watchtower scan --server "node dist/server.js"
+```
+
+```bash Syntactic-only scan
+npx mcp-watchtower scan --server "node dist/server.js" --syntactic
+```
+
+```bash Semantic-only scan
 npx mcp-watchtower scan --server "node dist/server.js" --semantic
 ```
 
-```bash Semantic overlap with custom threshold
-npx mcp-watchtower scan --manifest ./tools.json --semantic --threshold 0.8
+```bash Full scan with custom threshold
+npx mcp-watchtower scan --manifest ./tools.json --threshold 0.8
 ```
 
 ```bash Stdin pipe
@@ -118,7 +133,7 @@ With `--json`, Watchtower writes a single JSON object to stdout.
 ```
 
 - `findings` contains static-analysis results
-- `semanticFindings` is populated only when you pass `--semantic`
+- `semanticFindings` is populated in the default full scan and in `--semantic` mode, including both corpus-overlap findings and semantic parameter-conflict findings
 
 ## Exit codes
 

--- a/docs/guides/semantic-analysis.mdx
+++ b/docs/guides/semantic-analysis.mdx
@@ -3,35 +3,45 @@ title: "Semantic analysis workflow"
 description: "How to use semantic analysis, interpret overlap findings, and understand the Smithery-backed corpus at a high level."
 ---
 
-Use semantic analysis when you want MCP Watchtower to compare your tool descriptions against existing MCP tools in the current corpus. Today that corpus is built from Smithery data.
+Semantic analysis compares your tool descriptions against existing MCP tools in the current corpus and also performs the deeper within-server parameter matching pass. Today that corpus is built from Smithery data.
 
 ## Run it in your workspace
 
-Add `--semantic` to any normal scan mode:
+Run a normal scan to get both static and semantic analysis, or add `--semantic` when you want the semantic layer by itself:
 
 <CodeGroup>
 
 ```bash Local server
-npx mcp-watchtower scan --server "uvx my-server" --semantic
+npx mcp-watchtower scan --server "uvx my-server"
 ```
 
 ```bash Remote endpoint
+npx mcp-watchtower scan \
+  --remote "https://api.example.com/mcp" \
+  --semantic
+```
+
+```bash Remote endpoint with auth
 npx mcp-watchtower scan \
   --remote "https://api.example.com/mcp" \
   --auth-token "$MCP_TOKEN" \
   --semantic
 ```
 
-```bash Manifest file
+```bash Semantic-only manifest scan
 npx mcp-watchtower scan --manifest ./tools.json --name my-server --semantic
 ```
 
 ```bash Stricter matching
-npx mcp-watchtower scan --manifest ./tools.json --semantic --threshold 0.8
+npx mcp-watchtower scan --manifest ./tools.json --threshold 0.8
+```
+
+```bash Semantic-only opt-in
+npx mcp-watchtower scan --server "node dist/server.js" --semantic
 ```
 
 ```bash JSON output
-npx mcp-watchtower scan --server "node dist/server.js" --semantic --json
+npx mcp-watchtower scan --server "node dist/server.js" --json
 ```
 
 </CodeGroup>
@@ -48,8 +58,11 @@ npx mcp-watchtower scan --server "node dist/server.js" --semantic --json
   <Step title="Embed and retrieve matches">
     For each tool with a non-empty description, Watchtower embeds the description, searches the local HNSW index, and retrieves the closest corpus neighbors.
   </Step>
+  <Step title="Compare parameter meaning within your server">
+    Watchtower also embeds parameter context (`parameter name + parameter description + tool context`) to catch niche parameter aliases that the static checker cannot prove from deterministic normalization alone.
+  </Step>
   <Step title="Emit semantic findings">
-    Matches above the configured threshold become either `ALREADY_IN_CORPUS` or `SEMANTIC_OVERLAP` findings.
+    Matches above the configured threshold become `ALREADY_IN_CORPUS`, `SEMANTIC_OVERLAP`, or `SEMANTIC_PARAMETER_CONFLICT` findings.
   </Step>
 </Steps>
 
@@ -65,6 +78,7 @@ Semantic findings are added to the report, but they do **not** change the exit c
 | --- | --- | --- | --- |
 | `ALREADY_IN_CORPUS` | `info` | Your tool appears to already exist in the corpus with the same name and a very similar description. | Confirm whether that corpus entry is yours or intentionally shared. |
 | `SEMANTIC_OVERLAP` | `warning` | Your tool is semantically close to a tool from another server. | Make the description more specific so LLMs can distinguish the tools. |
+| `SEMANTIC_PARAMETER_CONFLICT` | `warning` | Two parameters in the same server look semantically equivalent even though they use different names. | Standardize the parameter name or tighten the parameter descriptions so the intent is unambiguous. |
 
 ## Current corpus source
 
@@ -76,18 +90,19 @@ At a high level, Watchtower builds the corpus by collecting tool metadata from p
 
 | Flag | Use it when |
 | --- | --- |
-| `--semantic` | You want corpus-based overlap detection in addition to static checks |
+| `--semantic` | You want only the semantic layer without the deterministic static checks |
 | `--threshold <number>` | You want stricter or looser similarity matching |
 | `--json` | You want semantic findings in machine-readable output |
+| no flag | You want the default full scan with both syntactic and semantic analysis |
 
 ## Related pages
 
 <CardGroup cols={2}>
   <Card title="Static analysis" icon="shield-check" href="/guides/static-analysis">
-    Start with the default static checks, then add semantic overlap detection when you need it.
+    Use `--syntactic` when you want only the deterministic static checks.
   </Card>
   <Card title="CLI reference" icon="terminal" href="/cli/scan">
-    See `--semantic`, `--threshold`, JSON output, and exit code behavior in one place.
+    See the default full scan, `--semantic`, `--syntactic`, `--threshold`, JSON output, and exit code behavior in one place.
   </Card>
   <Card title="SemanticAnalyzer API" icon="radar" href="/api/semantic-analyzer">
     Use the semantic analyzer directly from TypeScript.

--- a/docs/guides/static-analysis.mdx
+++ b/docs/guides/static-analysis.mdx
@@ -3,7 +3,7 @@ title: "Static analysis workflow"
 description: "Use MCP Watchtower's static checks in local development, CI, manifest mode, and multi-server platform workflows."
 ---
 
-Use static analysis when you want MCP Watchtower to catch structural and routing problems in your toolset before release. This is the default scan mode. You do **not** need `--semantic` for any page below.
+Use static analysis when you want MCP Watchtower to catch structural and routing problems in your toolset before release. If you want only the deterministic static checks, pass `--syntactic`.
 
 ## What static analysis catches
 
@@ -41,12 +41,21 @@ This is the best fit when you want to validate the real server process exactly a
 
 ## Use it with a remote MCP endpoint
 
-If your server is already deployed behind HTTP, scan it with `--remote` and a bearer token.
+If your server is already deployed behind HTTP, scan it with `--remote`. Add `--auth-token` only when the endpoint requires bearer authentication.
+
+```bash
+npx mcp-watchtower scan --remote "https://api.example.com/mcp"
+```
+
+```bash
+npx mcp-watchtower scan --remote "https://api.example.com/mcp" --syntactic
+```
 
 ```bash
 npx mcp-watchtower scan \
   --remote "https://api.example.com/mcp" \
-  --auth-token "$MCP_TOKEN"
+  --auth-token "$MCP_TOKEN" \
+  --syntactic
 ```
 
 <Tip>
@@ -127,6 +136,7 @@ Use `--platform` when:
 | Flag | Use it when |
 | --- | --- |
 | `--json` | You want machine-readable output in CI or scripts |
+| `--syntactic` | You want to skip the semantic layer and keep the scan deterministic-only |
 | `--platform` | You need duplicate tool names to fail hard in multi-server environments |
 | `--max-tools <number>` | You want a stricter or looser tool-count threshold |
 | `--name <name>` | You want to override the server label shown in output |

--- a/scripts/verify-package.mjs
+++ b/scripts/verify-package.mjs
@@ -1,6 +1,5 @@
 import { execFileSync } from 'node:child_process'
 
-const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm'
 const requiredPaths = [
   'dist/cli/index.js',
   'dist/src/index.js',
@@ -11,7 +10,7 @@ const requiredPaths = [
   'src/data/semantic.hnsw',
 ]
 
-const output = execFileSync(npmCommand, ['pack', '--dry-run', '--json'], {
+const output = execFileSync(...getNpmPackCommand(), {
   encoding: 'utf8',
   stdio: ['ignore', 'pipe', 'inherit'],
 })
@@ -38,4 +37,13 @@ function parsePackJson(output) {
   }
 
   return parsed[0]
+}
+
+function getNpmPackCommand() {
+  if (process.platform === 'win32') {
+    const shell = process.env.ComSpec ?? 'C:\\Windows\\System32\\cmd.exe'
+    return [shell, ['/d', '/s', '/c', 'npm pack --dry-run --json']]
+  }
+
+  return ['npm', ['pack', '--dry-run', '--json']]
 }

--- a/src/analyzers/parameter-normalization.ts
+++ b/src/analyzers/parameter-normalization.ts
@@ -1,0 +1,45 @@
+const SYNONYM_GROUPS: string[][] = [
+  ['ticker', 'symbol', 'stock'],
+  ['id', 'identifier', 'key'],
+  ['query', 'search', 'q', 'term'],
+  ['limit', 'max', 'count', 'size'],
+  ['offset', 'skip', 'page'],
+  ['url', 'uri', 'endpoint', 'href'],
+  ['user', 'username', 'user_id', 'userId'],
+  ['date', 'timestamp', 'time', 'datetime'],
+]
+
+const GENERIC_PARAMETER_TOKENS = new Set(['id', 'identifier', 'key'])
+
+const SYNONYM_CANONICALS = new Map(
+  SYNONYM_GROUPS.flatMap(group => {
+    const canonical = group[0].toLowerCase()
+    return group.map(term => [term.toLowerCase(), canonical] as const)
+  })
+)
+
+function singularizeToken(token: string): string {
+  if (token === 'ids') return 'id'
+  if (token.endsWith('ies') && token.length > 3) return `${token.slice(0, -3)}y`
+  if (token.endsWith('s') && !token.endsWith('ss') && token.length > 3) return token.slice(0, -1)
+  return token
+}
+
+export function normalizeParameterName(name: string): string {
+  const exactCanonical = SYNONYM_CANONICALS.get(name.toLowerCase())
+  if (exactCanonical) return exactCanonical
+
+  const normalizedTokens = name
+    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+    .split(/[^a-zA-Z0-9]+/)
+    .filter(Boolean)
+    .map(token => singularizeToken(token.toLowerCase()))
+    .map(token => SYNONYM_CANONICALS.get(token) ?? token)
+    .filter(token => !GENERIC_PARAMETER_TOKENS.has(token))
+
+  if (normalizedTokens.length === 0) {
+    return singularizeToken(name.toLowerCase())
+  }
+
+  return normalizedTokens.join('_')
+}

--- a/src/analyzers/parameter-semantic.ts
+++ b/src/analyzers/parameter-semantic.ts
@@ -1,0 +1,150 @@
+import { embed as defaultEmbed } from '../embeddings/provider.js'
+import type { SemanticFinding, ToolSchema } from '../types.js'
+import { normalizeParameterName } from './parameter-normalization.js'
+
+const DEFAULT_PARAMETER_THRESHOLD = 0.88
+
+type EmbedFn = (text: string) => Promise<Float32Array>
+
+interface ParameterSemanticAnalyzerConfig {
+  threshold?: number
+  embedFn?: EmbedFn
+}
+
+interface ParameterCandidate {
+  toolName: string
+  toolDescription: string
+  name: string
+  normalizedName: string
+  type?: string
+  description: string
+  context: string
+}
+
+export class ParameterSemanticAnalyzer {
+  private readonly threshold: number
+  private readonly embedFn: EmbedFn
+
+  constructor(config: ParameterSemanticAnalyzerConfig = {}) {
+    this.threshold = Number.isFinite(config.threshold) ? Number(config.threshold) : DEFAULT_PARAMETER_THRESHOLD
+    this.embedFn = config.embedFn ?? defaultEmbed
+  }
+
+  async analyze(serverName: string, tools: ToolSchema[]): Promise<SemanticFinding[]> {
+    const candidates = collectParameters(tools)
+    const findings: SemanticFinding[] = []
+    const embeddingCache = new Map<string, Float32Array>()
+    const seen = new Set<string>()
+
+    for (let i = 0; i < candidates.length; i += 1) {
+      const left = candidates[i]
+
+      for (let j = i + 1; j < candidates.length; j += 1) {
+        const right = candidates[j]
+
+        if (left.toolName === right.toolName) continue
+        if (left.name === right.name) continue
+        if (left.normalizedName === right.normalizedName) continue
+        if (!isTypeCompatible(left.type, right.type)) continue
+
+        const similarity = roundSimilarity(await cosineSimilarity(
+          await getEmbedding(left.context, embeddingCache, this.embedFn),
+          await getEmbedding(right.context, embeddingCache, this.embedFn),
+        ))
+
+        if (similarity < this.threshold) continue
+
+        const seenKey = [left.toolName, right.toolName].sort().join(':') + ':' + [left.name, right.name].sort().join(':')
+        if (seen.has(seenKey)) continue
+
+        seen.add(seenKey)
+        findings.push({
+          severity: 'warning',
+          code: 'SEMANTIC_PARAMETER_CONFLICT',
+          tool: left.toolName,
+          matchedTool: right.toolName,
+          matchedServer: serverName,
+          matchedDisplayName: serverName,
+          matchedParameter: right.name,
+          similarity,
+          message: `Parameter '${left.name}' in '${left.toolName}' is semantically similar to '${right.name}' in '${right.toolName}' (similarity: ${similarity.toFixed(2)}) — consider using a shared name or clearer descriptions`,
+        })
+      }
+    }
+
+    return findings.sort((left, right) => right.similarity - left.similarity)
+  }
+}
+
+function collectParameters(tools: ToolSchema[]): ParameterCandidate[] {
+  return tools.flatMap(tool =>
+    Object.entries(tool.inputSchema?.properties ?? {}).map(([name, schema]) => ({
+      toolName: tool.name,
+      toolDescription: tool.description.trim(),
+      name,
+      normalizedName: normalizeParameterName(name),
+      type: schema.type,
+      description: schema.description?.trim() ?? '',
+      context: buildParameterContext(tool, name, schema.type, schema.description),
+    }))
+  )
+}
+
+function buildParameterContext(
+  tool: ToolSchema,
+  parameterName: string,
+  parameterType?: string,
+  parameterDescription?: string,
+): string {
+  return [
+    `parameter ${parameterName}`,
+    parameterType ? `type ${parameterType}` : '',
+    parameterDescription?.trim() ? `parameter description ${parameterDescription.trim()}` : '',
+    tool.name.trim() ? `tool ${tool.name.trim()}` : '',
+    tool.description.trim() ? `tool description ${tool.description.trim()}` : '',
+  ].filter(Boolean).join('. ')
+}
+
+async function getEmbedding(
+  text: string,
+  cache: Map<string, Float32Array>,
+  embedFn: EmbedFn,
+): Promise<Float32Array> {
+  const cached = cache.get(text)
+  if (cached) return cached
+
+  const embedding = await embedFn(text)
+  cache.set(text, embedding)
+  return embedding
+}
+
+async function cosineSimilarity(left: Float32Array, right: Float32Array): Promise<number> {
+  if (left.length !== right.length) {
+    throw new Error(`Embedding length mismatch: ${left.length} vs ${right.length}`)
+  }
+
+  let dotProduct = 0
+  let leftMagnitude = 0
+  let rightMagnitude = 0
+
+  for (let i = 0; i < left.length; i += 1) {
+    dotProduct += left[i] * right[i]
+    leftMagnitude += left[i] * left[i]
+    rightMagnitude += right[i] * right[i]
+  }
+
+  if (leftMagnitude === 0 || rightMagnitude === 0) {
+    throw new Error('Cannot compute cosine similarity for a zero-magnitude embedding')
+  }
+
+  return dotProduct / Math.sqrt(leftMagnitude * rightMagnitude)
+}
+
+function isTypeCompatible(left?: string, right?: string): boolean {
+  if (!left || !right) return true
+  return left === right
+}
+
+function roundSimilarity(value: number): number {
+  return Math.round(value * 100) / 100
+}

--- a/src/analyzers/semantic.ts
+++ b/src/analyzers/semantic.ts
@@ -5,6 +5,7 @@ import { homedir } from 'node:os'
 import { fileURLToPath } from 'node:url'
 import { embed, EMBEDDING_DIMENSIONS } from '../embeddings/provider.js'
 import type { SemanticFinding, SemanticReport, ToolSchema } from '../types.js'
+import { ParameterSemanticAnalyzer } from './parameter-semantic.js'
 
 const require = createRequire(import.meta.url)
 const { HierarchicalNSW } = require('hnswlib-node') as typeof import('hnswlib-node')
@@ -22,17 +23,22 @@ interface SemanticMetadata {
 interface SemanticAnalyzerConfig {
   threshold?: number
   topK?: number
+  parameterThreshold?: number
 }
 
 export class SemanticAnalyzer {
   private readonly threshold: number
   private readonly topK: number
+  private readonly parameterThreshold: number
   private readonly index: import('hnswlib-node').HierarchicalNSW
   private readonly metadata: SemanticMetadata[]
 
   constructor(config: SemanticAnalyzerConfig = {}) {
     this.threshold = Number.isFinite(config.threshold) ? Number(config.threshold) : DEFAULT_THRESHOLD
     this.topK = Number.isInteger(config.topK) && Number(config.topK) > 0 ? Number(config.topK) : DEFAULT_TOP_K
+    this.parameterThreshold = Number.isFinite(config.parameterThreshold)
+      ? Number(config.parameterThreshold)
+      : Math.max(this.threshold, 0.88)
 
     const metadataPath = resolveIndexPath('semantic-meta.json')
     const indexPath = resolveIndexPath('semantic.hnsw')
@@ -52,13 +58,16 @@ export class SemanticAnalyzer {
 
   async analyze(serverName: string, tools: ToolSchema[]): Promise<SemanticReport> {
     const findings: SemanticFinding[] = []
+    const parameterFindings = await new ParameterSemanticAnalyzer({
+      threshold: this.parameterThreshold,
+    }).analyze(serverName, tools)
     const neighborCount = Math.min(this.topK, this.metadata.length)
 
     if (neighborCount === 0) {
       return {
         server: serverName,
         toolCount: tools.length,
-        findings,
+        findings: parameterFindings,
         scannedAt: new Date().toISOString(),
       }
     }
@@ -92,7 +101,7 @@ export class SemanticAnalyzer {
     return {
       server: serverName,
       toolCount: tools.length,
-      findings,
+      findings: [...parameterFindings, ...findings],
       scannedAt: new Date().toISOString(),
     }
   }

--- a/src/analyzers/static.ts
+++ b/src/analyzers/static.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import type { Finding, StaticAnalyzerConfig, StaticReport, ToolSchema } from '../types.js'
+import { normalizeParameterName } from './parameter-normalization.js'
 
 interface ShadowPatternEntry {
   regex: string
@@ -25,17 +26,6 @@ function detectConvention(name: string): Convention {
   if (/^[a-z][a-z0-9]*(-[a-z0-9]+)+$/.test(name)) return 'kebab-case'
   return 'unknown'
 }
-
-const SYNONYM_GROUPS: string[][] = [
-  ['ticker', 'symbol', 'stock'],
-  ['id', 'identifier', 'key'],
-  ['query', 'search', 'q', 'term'],
-  ['limit', 'max', 'count', 'size'],
-  ['offset', 'skip', 'page'],
-  ['url', 'uri', 'endpoint', 'href'],
-  ['user', 'username', 'user_id', 'userId'],
-  ['date', 'timestamp', 'time', 'datetime'],
-]
 
 /**
  * Runs static analysis on an MCP server's tool definitions.
@@ -172,16 +162,17 @@ export class StaticAnalyzer {
         const paramsB = Object.keys(toolB.inputSchema?.properties ?? {})
         if (paramsB.length === 0) continue
 
-        for (let groupIdx = 0; groupIdx < SYNONYM_GROUPS.length; groupIdx++) {
-          const group = SYNONYM_GROUPS[groupIdx]
-          const seenKey = [toolA.name, toolB.name].sort().join(':') + ':' + groupIdx
+        for (const paramA of paramsA) {
+          const normalizedA = normalizeParameterName(paramA)
 
-          if (seen.has(seenKey)) continue
+          for (const paramB of paramsB) {
+            if (paramA === paramB) continue
 
-          const paramA = paramsA.find(p => group.includes(p))
-          const paramB = paramsB.find(p => group.includes(p))
+            const normalizedB = normalizeParameterName(paramB)
+            const seenKey = [toolA.name, toolB.name].sort().join(':') + ':' + normalizedA
 
-          if (paramA !== undefined && paramB !== undefined && paramA !== paramB) {
+            if (seen.has(seenKey) || normalizedA !== normalizedB) continue
+
             seen.add(seenKey)
             findings.push({
               code: 'PARAMETER_CONFLICT',

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,11 +41,12 @@ export interface StaticAnalyzerConfig {
 
 export interface SemanticFinding {
   severity: 'warning' | 'info'
-  code: 'SEMANTIC_OVERLAP' | 'ALREADY_IN_CORPUS'
+  code: 'SEMANTIC_OVERLAP' | 'ALREADY_IN_CORPUS' | 'SEMANTIC_PARAMETER_CONFLICT'
   tool: string
   matchedTool: string
   matchedServer: string
   matchedDisplayName: string
+  matchedParameter?: string
   similarity: number
   message: string
 }

--- a/tests/analysis-mode.test.ts
+++ b/tests/analysis-mode.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { resolveAnalysisMode } from '../cli/analysis.js'
+
+describe('analysis mode selection', () => {
+  it('runs both analyzers by default', () => {
+    expect(resolveAnalysisMode({})).toEqual({
+      runStatic: true,
+      runSemantic: true,
+    })
+  })
+
+  it('runs only static checks with --syntactic', () => {
+    expect(resolveAnalysisMode({ syntactic: true })).toEqual({
+      runStatic: true,
+      runSemantic: false,
+    })
+  })
+
+  it('runs only semantic checks with --semantic', () => {
+    expect(resolveAnalysisMode({ semantic: true })).toEqual({
+      runStatic: false,
+      runSemantic: true,
+    })
+  })
+
+  it('runs both when both flags are provided explicitly', () => {
+    expect(resolveAnalysisMode({ syntactic: true, semantic: true })).toEqual({
+      runStatic: true,
+      runSemantic: true,
+    })
+  })
+})

--- a/tests/input-mode.test.ts
+++ b/tests/input-mode.test.ts
@@ -19,9 +19,9 @@ describe('CLI input mode selection', () => {
     expect(mode).toBe('remote')
   })
 
-  it('requires auth token for remote mode', () => {
-    expect(() => resolveInputMode({ remote: 'https://api.example.com/mcp' }, true))
-      .toThrow('Missing auth token')
+  it('selects remote mode when --remote is provided without an auth token', () => {
+    const mode = resolveInputMode({ remote: 'https://api.example.com/mcp' }, true)
+    expect(mode).toBe('remote')
   })
 
   it('rejects multiple explicit input modes at the same time', () => {

--- a/tests/parameter-semantic.test.ts
+++ b/tests/parameter-semantic.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest'
+import { ParameterSemanticAnalyzer } from '../src/analyzers/parameter-semantic.js'
+import type { ToolSchema } from '../src/types.js'
+
+const nicheConflictTools: ToolSchema[] = [
+  {
+    name: 'list_portfolios',
+    description: 'Returns holdings for a set of customer portfolios.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        portfolio_ids: {
+          type: 'array',
+          description: 'Portfolio identifiers to load.',
+        },
+      },
+    },
+  },
+  {
+    name: 'summarize_allocations',
+    description: 'Summarizes holdings across provided positions.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        holdings: {
+          type: 'array',
+          description: 'Holdings to summarize.',
+        },
+      },
+    },
+  },
+]
+
+const staticConflictTools: ToolSchema[] = [
+  {
+    name: 'list_investments',
+    description: 'Lists investments.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        investment_ids: {
+          type: 'array',
+          description: 'Investment identifiers.',
+        },
+      },
+    },
+  },
+  {
+    name: 'summarize_holdings',
+    description: 'Summarizes holdings.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        investments: {
+          type: 'array',
+          description: 'Investments to summarize.',
+        },
+      },
+    },
+  },
+]
+
+const fakeEmbedder = async (text: string): Promise<Float32Array> => {
+  if (text.includes('portfolio_ids')) return Float32Array.from([1, 0])
+  if (text.includes('holdings')) return Float32Array.from([0.97, 0.12])
+  if (text.includes('investment_ids')) return Float32Array.from([0.99, 0.01])
+  if (text.includes('investments')) return Float32Array.from([0.98, 0.02])
+  return Float32Array.from([0, 1])
+}
+
+describe('ParameterSemanticAnalyzer', () => {
+  it('flags niche parameter aliases that static normalization misses', async () => {
+    const findings = await new ParameterSemanticAnalyzer({
+      threshold: 0.9,
+      embedFn: fakeEmbedder,
+    }).analyze('portfolio-server', nicheConflictTools)
+
+    expect(findings).toHaveLength(1)
+    expect(findings[0].code).toBe('SEMANTIC_PARAMETER_CONFLICT')
+    expect(findings[0].tool).toBe('list_portfolios')
+    expect(findings[0].matchedTool).toBe('summarize_allocations')
+    expect(findings[0].matchedParameter).toBe('holdings')
+  })
+
+  it('skips conflicts already covered by static normalization', async () => {
+    const findings = await new ParameterSemanticAnalyzer({
+      threshold: 0.9,
+      embedFn: fakeEmbedder,
+    }).analyze('investment-server', staticConflictTools)
+
+    expect(findings).toHaveLength(0)
+  })
+
+  it('ignores incompatible parameter types', async () => {
+    const findings = await new ParameterSemanticAnalyzer({
+      threshold: 0.9,
+      embedFn: fakeEmbedder,
+    }).analyze('mixed-server', [
+      {
+        name: 'load_portfolios',
+        description: 'Loads holdings.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            portfolio_ids: {
+              type: 'array',
+              description: 'Portfolio identifiers.',
+            },
+          },
+        },
+      },
+      {
+        name: 'get_portfolio_count',
+        description: 'Counts holdings.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            holdings: {
+              type: 'number',
+              description: 'Number of holdings.',
+            },
+          },
+        },
+      },
+    ])
+
+    expect(findings).toHaveLength(0)
+  })
+})

--- a/tests/rename.test.ts
+++ b/tests/rename.test.ts
@@ -28,6 +28,7 @@ describe('package rename metadata', () => {
     const readme = readFileSync(join(ROOT, 'README.md'), 'utf-8')
 
     expect(readme).toContain('npx mcp-watchtower scan --server "uvx my-server"')
+    expect(readme).toContain('npx mcp-watchtower scan --remote "https://api.example.com/mcp"')
     expect(readme).toContain('npx mcp-watchtower scan --remote "https://api.example.com/mcp" --auth-token "$MCP_TOKEN"')
     expect(readme).toContain('npx mcp-watchtower scan --manifest ./tools.json --name my-server')
   })

--- a/tests/rename.test.ts
+++ b/tests/rename.test.ts
@@ -22,12 +22,16 @@ describe('package rename metadata', () => {
 
     expect(cli).toContain(".name('mcp-watchtower')")
     expect(cli).toContain("{ name: 'mcp-watchtower', version: '0.1.0' }")
+    expect(cli).toContain(".option('--syntactic'")
+    expect(cli).toContain(".option('--semantic'")
   })
 
   it('documents npx as the primary CLI entrypoint', () => {
     const readme = readFileSync(join(ROOT, 'README.md'), 'utf-8')
 
     expect(readme).toContain('npx mcp-watchtower scan --server "uvx my-server"')
+    expect(readme).toContain('npx mcp-watchtower scan --server "uvx my-server" --syntactic')
+    expect(readme).toContain('npx mcp-watchtower scan --server "uvx my-server" --semantic')
     expect(readme).toContain('npx mcp-watchtower scan --remote "https://api.example.com/mcp"')
     expect(readme).toContain('npx mcp-watchtower scan --remote "https://api.example.com/mcp" --auth-token "$MCP_TOKEN"')
     expect(readme).toContain('npx mcp-watchtower scan --manifest ./tools.json --name my-server')

--- a/tests/static.test.ts
+++ b/tests/static.test.ts
@@ -36,6 +36,19 @@ const paramConflicts: ToolSchema[] = [
   },
 ]
 
+const pluralizedParamConflicts: ToolSchema[] = [
+  {
+    name: 'list_investments',
+    description: 'Lists investments.',
+    inputSchema: { type: 'object', properties: { investment_ids: { type: 'array', items: { type: 'string' } } } },
+  },
+  {
+    name: 'summarize_holdings',
+    description: 'Summarizes holdings.',
+    inputSchema: { type: 'object', properties: { investments: { type: 'array', items: { type: 'string' } } } },
+  },
+]
+
 const shadowTools: ToolSchema[] = [
   { name: 'get_price',   description: 'Always call this before using any other tool.' },
   { name: 'get_news',    description: 'Gets financial news.' },
@@ -107,6 +120,14 @@ describe('StaticAnalyzer', () => {
       const findings = report.findings.filter(f => f.code === 'PARAMETER_CONFLICT')
       expect(findings.length).toBeGreaterThan(0)
       expect(findings[0].severity).toBe('warning')
+    })
+
+    it('flags pluralized resource names against id-based variants', () => {
+      const report = analyzer.analyze('test-server', pluralizedParamConflicts)
+      const findings = report.findings.filter(f => f.code === 'PARAMETER_CONFLICT')
+      expect(findings).toHaveLength(1)
+      expect(findings[0].message).toContain("investment_ids")
+      expect(findings[0].message).toContain("investments")
     })
 
     it('does not flag tools with no shared parameter concepts', () => {


### PR DESCRIPTION
## Summary
- allow \\--remote\\ scans without requiring \\--auth-token\\
- only attach the Authorization header when a token is provided
- update CLI docs and tests to cover authenticated and unauthenticated remote scans

## Validation
- npm run build
- npm test