### PR TITLE
Polish README for public launch and fix manifest name derivation

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Use `--platform` to treat static name collisions as critical.
 | Static | Duplicate names, naming convention drift, suspicious descriptions, excessive tool counts | Yes, for critical findings |
 | Semantic | `ALREADY_IN_CORPUS`, `SEMANTIC_OVERLAP`, `SEMANTIC_PARAMETER_CONFLICT` | No, warning/informational only |
 
-Exit code `0` means no critical static findings were found. Exit code `1` means at least one critical static finding was found.
+Exit code `0` means no critical static findings were found and the scan completed successfully. Exit code `1` means either at least one critical static finding was found or the CLI encountered a runtime/usage error (for example, invalid input or a connection failure).
 
 ## Programmatic usage
 

--- a/README.md
+++ b/README.md
@@ -1,48 +1,39 @@
-# mcp-watchtower
+# MCP Watchtower
 
-Analyze MCP servers for naming, routing, and semantic tool conflicts.
+> Analyze MCP servers for naming, routing, and semantic tool conflicts before they confuse agents or collide with the wider MCP ecosystem.
 
-![Index refresh](https://github.com/ariroffe72/mcp-watchtower/actions/workflows/refresh-index.yml/badge.svg)
-
+[![Index refresh](https://github.com/ariroffe72/mcp-watchtower/actions/workflows/refresh-index.yml/badge.svg)](https://github.com/ariroffe72/mcp-watchtower/actions/workflows/refresh-index.yml)
 ![Index updated](https://img.shields.io/badge/dynamic/json?url=https://pub-0eeb51ca45a14ebe89372cca3f4bea7f.r2.dev/manifest.json&query=$.version&label=index%20updated&color=blue)
 
-**Docs:** https://self-5d39fc87.mintlify.app/
-
-## Overview
-
-![MCP Watchtower Workflow](https://raw.githubusercontent.com/ariroffe72/mcp-watchtower/main/docs/assets/diagrams/mcp-watchtower-workflow.png)
-
-> Figure: MCP Watchtower performs static validation and semantic comparison against a continuously updated MCP corpus to detect collisions and quality issues.
-
-`mcp-watchtower` analyzes an MCP server (local, remote, or manifest) and produces two types of findings:
-
-- **Static findings** from deterministic checks for naming, routing, and other structural issues.
-- **Semantic findings** from deeper comparison against the MCP corpus to detect tool conflicts and overlap.
-
-## Quick start
+**Documentation:** [Get started](https://self-5d39fc87.mintlify.app/introduction) · [CLI reference](https://self-5d39fc87.mintlify.app/cli/scan) · [Checks](https://self-5d39fc87.mintlify.app/checks/overview) · [API](https://self-5d39fc87.mintlify.app/api/overview)
 
 ```bash
 npx mcp-watchtower scan --server "uvx my-server"
 ```
 
-By default, a scan runs both the deterministic static checks and the deeper semantic analysis pass.
+## Why it exists
 
-Human-readable scans print findings after analysis completes. When using `--json`, stdout contains the final JSON payload, but progress and status messages may still be written to stderr.
+MCP servers are easy to publish, but hard to compare. Two servers can expose tools that sound different to humans but look interchangeable to an agent, or they can define parameters that mean the same thing under different names.
 
-## Learn more
+MCP Watchtower scans a local server, remote endpoint, or manifest and reports:
 
-- [Get started](https://self-5d39fc87.mintlify.app/introduction)
-- [CLI reference](https://self-5d39fc87.mintlify.app/cli/scan)
-- [Checks overview](https://self-5d39fc87.mintlify.app/checks/overview)
-- [API reference](https://self-5d39fc87.mintlify.app/api/overview)
+- **Static issues** such as duplicate tool names, inconsistent naming, prompt-shadowing descriptions, and oversized tool sets.
+- **Semantic overlap** against a continuously refreshed MCP corpus so you can spot tools that already exist or need clearer boundaries.
+- **Parameter conflicts** where equivalent concepts are named inconsistently inside the same server.
 
-## CLI Usage
+## How it works
+
+![MCP Watchtower workflow](https://raw.githubusercontent.com/ariroffe72/mcp-watchtower/main/docs/assets/diagrams/mcp-watchtower-workflow.png)
+
+MCP Watchtower combines deterministic static checks with semantic comparison against a published index. Scans keep working offline by falling back to the bundled index in `src/data/`.
+
+## Quick examples
 
 ```bash
 # Local MCP server over stdio
 npx mcp-watchtower scan --server "uvx my-server"
 
-# Remote MCP endpoint without auth
+# Remote MCP endpoint
 npx mcp-watchtower scan --remote "https://api.example.com/mcp"
 
 # Remote MCP endpoint with bearer auth
@@ -50,21 +41,18 @@ npx mcp-watchtower scan --remote "https://api.example.com/mcp" --auth-token "$MC
 
 # Manifest / CI input
 npx mcp-watchtower scan --manifest ./tools.json --name my-server
+
+# Machine-readable output
+npx mcp-watchtower scan --server "uvx my-server" --json
 ```
 
-### Useful flags
+Plain `scan` runs both static and semantic analysis. Common focused scans:
 
 ```bash
-# JSON output
-npx mcp-watchtower scan --server "uvx my-server" --json
-
-# Treat static name collisions as critical
-npx mcp-watchtower scan --server "uvx my-server" --platform
-
-# Syntactic-only scan
+# Static checks only
 npx mcp-watchtower scan --server "uvx my-server" --syntactic
 
-# Semantic-only scan
+# Semantic checks only
 npx mcp-watchtower scan --server "uvx my-server" --semantic
 
 # Expanded human-readable logging
@@ -74,44 +62,16 @@ npx mcp-watchtower scan --server "uvx my-server" --verbose
 npx mcp-watchtower scan --server "uvx my-server" --threshold 0.8
 ```
 
-`--auth-token` is optional for `--remote` and is only needed when the endpoint requires bearer authentication.
+Use `--platform` to treat static name collisions as critical.
 
-## What it checks
+## Findings at a glance
 
-### Static analysis
+| Layer | Examples | Affects exit code? |
+| --- | --- | --- |
+| Static | Duplicate names, naming convention drift, suspicious descriptions, excessive tool counts | Yes, for critical findings |
+| Semantic | `ALREADY_IN_CORPUS`, `SEMANTIC_OVERLAP`, `SEMANTIC_PARAMETER_CONFLICT` | No, warning/informational only |
 
-- duplicate tool names
-- inconsistent naming conventions
-- conflicting parameter names for the same concept
-- prompt-shadowing language in tool descriptions
-- excessive tool counts
-
-### Semantic analysis
-
-- `ALREADY_IN_CORPUS` — the tool appears to already exist in the corpus
-- `SEMANTIC_OVERLAP` — the tool looks close to an existing tool and may need clearer disambiguation
-- `SEMANTIC_PARAMETER_CONFLICT` — two parameters in the same server look semantically equivalent despite inconsistent names
-
-Plain `scan` runs both layers. Use `--syntactic` for only the deterministic checks or `--semantic` for only the deeper semantic pass.
-
-## Exit codes
-
-- `0` — no critical static findings
-- `1` — one or more critical static findings
-
-Semantic findings are informational or warning-level only and do **not** affect the exit code.
-
-## Index behavior
-
-Semantic analysis ships with a bundled fallback index in `src/data/`.
-
-On CLI startup, `mcp-watchtower` also checks the published CDN manifest and, if a newer index is available, downloads it to:
-
-```text
-~/.mcp-watchtower/index/
-```
-
-If the CDN is unavailable or the update fails, scans continue silently with the bundled index.
+Exit code `0` means no critical static findings were found. Exit code `1` means at least one critical static finding was found.
 
 ## Programmatic usage
 
@@ -122,73 +82,52 @@ const staticReport = new StaticAnalyzer().analyze('my-server', tools)
 const semanticReport = await new SemanticAnalyzer().analyze('my-server', tools)
 ```
 
+## Documentation
+
+The full docs include setup guidance, deeper explanations, and API references:
+
+- [Introduction](https://self-5d39fc87.mintlify.app/introduction)
+- [CLI scan command](https://self-5d39fc87.mintlify.app/cli/scan)
+- [Checks overview](https://self-5d39fc87.mintlify.app/checks/overview)
+- [Static analysis guide](https://self-5d39fc87.mintlify.app/guides/static-analysis)
+- [Semantic analysis guide](https://self-5d39fc87.mintlify.app/guides/semantic-analysis)
+- [API overview](https://self-5d39fc87.mintlify.app/api/overview)
+
 ## Development
 
 ```bash
+npm install
 npm run build
 npm test
 npm run pack:check
+```
+
+Run the compiled CLI from a local clone:
+
+```bash
+node dist/cli/index.js scan --server "uvx my-server"
+```
+
+Useful maintenance commands:
+
+```bash
 npm run crawl
 npm run embed
 npm run build-index
 npm run publish-index
 ```
 
-If you're working from a local clone instead of npm, build first and run the compiled CLI directly:
+`publish-index` rebuilds the corpus, embeddings, and semantic index, then uploads the refreshed assets and manifest to Cloudflare R2. The nightly GitHub Actions workflow in `.github/workflows/refresh-index.yml` runs the same publish step automatically.
 
-```bash
-npm install
-npm run build
-node dist/cli/index.js scan --server "uvx my-server"
-```
+## Release notes for maintainers
 
-`publish-index` rebuilds the corpus, embeddings, and semantic index, then uploads the refreshed assets and manifest to Cloudflare R2. The nightly GitHub Actions workflow at `.github/workflows/refresh-index.yml` runs the same publish step automatically.
+Package releases use Changesets and are separate from semantic index refreshes.
 
-## Releasing the package
+- Add a normal changeset for user-visible package changes.
+- Use `npx changeset --empty` for intentional no-release work.
+- Validate release artifacts with `npm run build`, `npm test`, and `npm run pack:check`.
+- The `release.yml` workflow publishes pending changesets to npm after merge to `main`.
 
-`mcp-watchtower` should be released with Changesets, separate from the semantic index refresh pipeline.
+## License
 
-1. Add a changeset in the same PR as any user-visible package change:
-
-   ```bash
-   npm run changeset
-   ```
-
-2. Merge the PR into `main`.
-3. The `release.yml` workflow will apply pending changesets on `main`, commit the version bump back to `main`, and publish the new package version to npm automatically.
-
-### Release requirements
-
-- Repository secret: `NPM_TOKEN` with permission to publish `mcp-watchtower`
-- The workflow's built-in `GITHUB_TOKEN` must be allowed to push the release commit back to `main` (or bypass branch protection for that commit)
-
-### When to add a changeset
-
-- Add a normal changeset for any user-visible change to behavior, CLI flags, shipped assets, or public library APIs.
-- If a PR should merge without producing a release, run:
-
-  ```bash
-  npx changeset --empty
-  ```
-
-  That records intentional "no release" work so reviewers and automation do not have to guess.
-
-### Local release validation
-
-Before publishing manually or debugging the workflow locally, validate the release artifact with:
-
-```bash
-npm run build
-npm test
-npm run pack:check
-```
-
-### If a release fails
-
-- If the workflow fails before publishing to npm, fix the issue on `main` and rerun the workflow on the latest `main` commit.
-- If npm publish fails because of auth or registry configuration, fix `NPM_TOKEN` or package permissions and rerun the workflow.
-- If the version bump commit already landed on `main` but npm did not receive the package, inspect the failed Actions logs and rerun the workflow on the latest `main` commit instead of changing the version again.
-
-## Semantic index releases
-
-The semantic index is intentionally released on its own cadence. `.github/workflows/refresh-index.yml` continues to rebuild and publish the Cloudflare R2 assets independently of npm package releases.
+MIT

--- a/cli/input.ts
+++ b/cli/input.ts
@@ -1,5 +1,3 @@
-import { basename } from 'node:path'
-
 export interface ScanInputOptions {
   server?: string
   remote?: string
@@ -55,6 +53,6 @@ export function deriveServerNameFromUrl(endpoint: string): string {
 }
 
 export function deriveServerNameFromManifest(manifestPath: string): string {
-  const filename = basename(manifestPath)
+  const filename = manifestPath.split(/[\\/]/).pop() ?? ''
   return filename.replace(/\.[^.]+$/, '') || 'manifest'
 }


### PR DESCRIPTION
### Motivation
- Make the repository README a concise, public-facing landing page that highlights value, provides immediate “try it now” examples, and surfaces documentation links for Reddit/job-application readers.
- Improve the placement of the workflow diagram and reduce duplicated or overly long operational prose to keep the top-level README scannable.
- Fix a Windows-path handling bug that caused server-name derivation (manifest-based) to return backslash-containing strings and break tests.

### Description
- Reworked `README.md` to a focused landing format with a stronger headline, prominent docs links, moved workflow diagram into a “How it works” section, condensed CLI examples, and a compact findings table.
- Replaced longer maintainer prose with a shorter development section and surfaced key maintenance commands and docs links more clearly.
- Updated `cli/input.ts` to remove the unused `basename` import and make `deriveServerNameFromManifest` split the path on both `/` and `\` so Windows-style manifest paths yield the correct filename.
- Small content/formatting edits to make the README easier to scan and share publicly without changing runtime behavior beyond the manifest-name fix.

### Testing
- Ran the test suite with `npm test` (Vitest) and all tests passed (`45 passed`).
- Built the project with `npm run build` and the TypeScript build plus postbuild steps completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fff3caf384832f9f0bf00b5e9fd228)